### PR TITLE
changed site template

### DIFF
--- a/Views/Site.cshtml
+++ b/Views/Site.cshtml
@@ -92,7 +92,7 @@
         <a href=@(SiteHelpers.GetSitePDFResourceURL(Model.Site.EUCode)) target="N2K">
             Standard Data Form
         </a>
-        for this site as submitted to Europe (PDF &lt;100kb)
+        for this site (PDF &lt;100kb)
     </p>
 </div>
 


### PR DESCRIPTION
Removed "as submitted to Europe" from the standard data form link on the site page